### PR TITLE
Refactor: tailwind class

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -12,7 +12,7 @@ export default function Alert({ title, contents, onConfirm }: AlertType) {
     <div className="bg-black/30 fixed inset-0 z-20 overflow-hidden flex w-screen h-screen">
       <div
         role="alert"
-        className="w-96 p-4 m-auto flex flex-col card-rounded card-red"
+        className="w-96 p-4 m-auto flex flex-col rounded-lg shadow bg-red-50 text-red-800 dark:bg-gray-800 dark:text-red-400"
       >
         <div className="flex items-center">
           <HiExclamationCircle className="w-5 h-5 mr-2" />
@@ -22,7 +22,7 @@ export default function Alert({ title, contents, onConfirm }: AlertType) {
         <button
           type="button"
           onClick={onConfirm}
-          className="font-medium rounded-lg text-xs px-4 py-1.5 text-center ml-auto button-red"
+          className="font-medium rounded-lg text-xs px-4 py-1.5 text-center ml-auto focus:ring-2 focus:outline-none text-white bg-red-800 hover:bg-red-900 focus:ring-red-300 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800"
         >
           확인
         </button>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -14,9 +14,9 @@ export default function Form({ title, onSubmit, children }: FormType) {
   };
 
   return (
-    <div className="w-full card-rounded card-white md:mt-0 sm:max-w-md xl:p-0">
+    <div className="w-full rounded-lg shadow bg-white dark:bg-gray-900 dark:border dark:border-gray-700 md:mt-0 sm:max-w-md xl:p-0">
       <div className="p-6 space-y-4 md:space-y-6 sm:p-8">
-        <h1 className="text-xl font-bold leading-tight tracking-tight text-black md:text-2xl">
+        <h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 dark:text-white md:text-2xl">
           {title}
         </h1>
         <form className="space-y-4 md:space-y-6" onSubmit={handleSubmit}>
@@ -56,7 +56,10 @@ function FormInput({
 
   return (
     <div className="space-y-1 pb-2">
-      <label htmlFor={name} className="block text-sm font-medium text-black">
+      <label
+        htmlFor={name}
+        className="block text-sm font-medium text-gray-900 dark:text-white"
+      >
         {label}
       </label>
       <input
@@ -64,8 +67,10 @@ function FormInput({
         name={name}
         id={name}
         className={`${
-          !validationVisible ? 'input-gray' : 'input-red'
-        } input-rounded block w-full p-2.5 sm:text-sm`}
+          !validationVisible
+            ? 'text-gray-900 dark:text-white placeholder-gray-400 bg-gray-50 border-gray-300 focus:ring-primary-600 focus:border-primary-600 dark:bg-gray-800 dark:border-gray-600 dark:focus:ring-primary-500 dark:focus:border-primary-500'
+            : 'text-red-500 border-red-500 focus:ring-red-500 focus:border-red-500 bg-red-50 placeholder-red-300 dark:bg-red-700/25 dark:placeholder-red-300/30'
+        } border rounded-lg focus:outline-none focus:ring-1 block w-full p-2.5 sm:text-sm`}
         placeholder={placeholder}
         value={value}
         onChange={onChange}
@@ -73,7 +78,7 @@ function FormInput({
       />
       {validationVisible && (
         <div className="absolute">
-          <p className="relative text-sm text-red">{errorText}</p>
+          <p className="relative text-sm text-red-500">{errorText}</p>
         </div>
       )}
     </div>
@@ -90,7 +95,7 @@ function FormButton({ text, disabled = false }: FormButtonType) {
     <button
       type="submit"
       disabled={disabled}
-      className="button-rounded-lg button-primary"
+      className="w-full px-5 py-2.5 rounded-lg font-medium text-sm text-center focus:outline-none focus:ring-2 bg-primary-600 hover:bg-primary-700 disabled:bg-primary-600/50 text-white focus:ring-primary-300 dark:disabled:text-gray-400 dark:focus:ring-primary-800"
     >
       {text}
     </button>
@@ -109,12 +114,12 @@ function FormHelper({
   navigatePath = '/',
 }: FormHelperType) {
   return (
-    <p className="text-sm text-gray font-light select-none">
+    <p className="text-sm text-gray-500 dark:text-gray-400 font-light select-none">
       {helpText}
       {navigateText !== '' && (
         <Link
           to={navigatePath}
-          className="font-medium text-primary hover:underline pl-1"
+          className="font-medium text-primary-600 dark:text-primary-500 hover:underline pl-1"
         >
           {navigateText}
         </Link>

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+type IconButtonProps = {
+  onClick: () => void;
+  ariaLabel: string;
+  children: React.ReactNode;
+};
+
+export default function IconButton({
+  onClick,
+  ariaLabel,
+  children,
+}: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      className="rounded-lg ml-auto -mx-1.5 -my-1.5 p-1.5 flex justify-center items-center h-8 w-8 focus:ring-1 focus:ring-gray-300 text-gray-400 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-gray-600 dark:hover:text-white"
+      onClick={onClick}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -11,7 +11,7 @@ export default function LogoutButton() {
   return (
     <button
       type="button"
-      className="button-rounded-sm button-gray"
+      className="py-1.5 px-2.5 rounded-lg font-medium text-sm border focus:ring-2 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:text-blue-700 bg-gray-50 text-gray-900 border-gray-200 hover:bg-gray-100 hover:text-primary-600 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:text-white"
       onClick={logout}
     >
       Logout

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -5,6 +5,8 @@ import useToast from 'src/hooks/useToast';
 
 import { deleteTodo, updateTodo } from 'src/api/handleTodo';
 
+import IconButton from 'src/components/IconButton';
+
 type TodoComponent = {
   id: number;
   todo: string;
@@ -71,34 +73,29 @@ export default function Todo({
   return (
     <>
       <Toast />
-      <div className={`${isCompleted && 'toggled'} todo todo-white`}>
+      <div
+        className={`${
+          isCompleted &&
+          'line-through bg-gray-200 text-gray-400 dark:bg-gray-800 dark:text-gray-600 dark:border-gray-700'
+        } rounded-lg flex w-full p-2.5 text-sm text-gray-900 dark:text-white border bg-white border-gray-300 dark:bg-gray-700 dark:border-gray-600`}
+      >
         {editMode ? (
           <>
             <textarea
               className={`${
                 isCompleted && 'dark:text-gray-400'
-              } flex-1 rounded-sm px-1 mr-1 bg-gray-100 dark:bg-gray-600`}
+              } flex-1 rounded-sm px-1 mr-1 bg-gray-100 dark:bg-gray-600 resize-none focus:outline-none`}
               value={todoValue}
               onChange={handleTodoValueChange}
             >
               {todo}
             </textarea>
-            <button
-              type="button"
-              className="icon-button"
-              onClick={editTodo}
-              aria-label="confirm"
-            >
+            <IconButton onClick={editTodo} ariaLabel="confirm">
               <HiCheck />
-            </button>
-            <button
-              type="button"
-              className="icon-button"
-              onClick={cancelEdit}
-              aria-label="cancel"
-            >
+            </IconButton>
+            <IconButton onClick={cancelEdit} ariaLabel="cancel">
               <HiX />
-            </button>
+            </IconButton>
           </>
         ) : (
           <>
@@ -109,22 +106,12 @@ export default function Todo({
             >
               {todo}
             </pre>
-            <button
-              type="button"
-              className="icon-button"
-              onClick={() => setEditMode(true)}
-              aria-label="edit"
-            >
+            <IconButton onClick={() => setEditMode(true)} ariaLabel="edit">
               <HiPencil />
-            </button>
-            <button
-              type="button"
-              className="icon-button"
-              onClick={removeTodo}
-              aria-label="delete"
-            >
+            </IconButton>
+            <IconButton onClick={removeTodo} ariaLabel="delete">
               <HiTrash />
-            </button>
+            </IconButton>
           </>
         )}
       </div>

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -75,9 +75,10 @@ export default function Todo({
       <Toast />
       <div
         className={`${
-          isCompleted &&
-          'line-through bg-gray-200 text-gray-400 dark:bg-gray-800 dark:text-gray-600 dark:border-gray-700'
-        } rounded-lg flex w-full p-2.5 text-sm text-gray-900 dark:text-white border bg-white border-gray-300 dark:bg-gray-700 dark:border-gray-600`}
+          isCompleted
+            ? 'line-through bg-gray-200 text-gray-400 dark:bg-gray-800 dark:text-gray-600 dark:border-gray-700'
+            : 'bg-white text-gray-900 dark:bg-gray-700 dark:text-white dark:border-gray-600'
+        } rounded-lg flex w-full p-2.5 text-sm border border-gray-300`}
       >
         {editMode ? (
           <>

--- a/src/components/TodoInput.tsx
+++ b/src/components/TodoInput.tsx
@@ -40,14 +40,14 @@ function TodoInput({ rerender }: TodoInputComponent) {
       <Toast />
       <form className="relative w-full mt-6" onSubmit={handleSubmit}>
         <input
-          className="block p-2.5 pr-[3.3rem] w-full text-sm input-rounded input-white"
+          className="block p-2.5 pr-[3.3rem] w-full text-sm border rounded-lg focus:outline-none focus:ring-1 text-gray-900 dark:text-white placeholder-gray-400 focus:border-blue-500 focus:ring-blue-500 bg-white border-gray-300 dark:bg-gray-700 dark:border-gray-600"
           placeholder="Input todos..."
           value={newTodo}
           onChange={handleChangeInput}
         />
         <button
           type="submit"
-          className="absolute top-0 right-0 p-2.5 text-sm font-medium rounded-r-lg button-primary border border-primary-600"
+          className="absolute top-0 right-0 p-2.5 text-sm font-medium rounded-r-lg focus:outline-none focus:ring-2 border bg-primary-600 hover:bg-primary-700 disabled:bg-primary-600/50 border-primary-600 text-white focus:ring-primary-300 dark:disabled:text-gray-400 dark:focus:ring-primary-800"
           aria-label="submit"
         >
           <HiOutlineChevronDown className="w-5 h-5" />

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -41,7 +41,7 @@ export default function TodoList({
   return (
     <div className="w-full mt-10 space-y-6">
       {error ? (
-        <div className="flex w-full justify-center text-center text-black leading-10">
+        <div className="flex w-full justify-center text-center text-gray-900 dark:text-white leading-10">
           오류로 인해 TodoList를 가져올 수 없습니다.
           <br />
           다시 시도해주세요.

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
 @tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @layer base {
   * {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
 @tailwind base;
-@tailwind components;
-@tailwind utilities;
 
 @layer base {
   * {
@@ -16,8 +14,7 @@
   }
 
   body {
-    @apply bg-gray-50;
-    @apply dark:bg-gray-900;
+    @apply bg-gray-50 dark:bg-gray-900;
   }
 
   pre {
@@ -25,10 +22,6 @@
       BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
       'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
       'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
-  }
-
-  textarea {
-    @apply resize-none focus:outline-none;
   }
 
   ::-webkit-scrollbar {
@@ -42,109 +35,5 @@
   }
   ::-webkit-scrollbar-button {
     @apply w-0 h-0;
-  }
-}
-
-@layer components {
-  .todo {
-    @apply rounded-lg flex w-full p-2.5 text-sm;
-  }
-  .todo-white {
-    @apply text-black border;
-    @apply bg-white border-gray-300;
-    @apply dark:bg-gray-700 dark:border-gray-600;
-  }
-
-  .card-rounded {
-    @apply rounded-lg shadow;
-  }
-  .card-white {
-    @apply bg-white;
-    @apply dark:border dark:border-gray-700;
-  }
-  .card-red {
-    @apply bg-red-50 text-red-800;
-    @apply dark:bg-gray-800 dark:text-red-400;
-  }
-
-  .input-rounded {
-    @apply border rounded-lg;
-    @apply focus:outline-none focus:ring-1;
-  }
-  .input-white {
-    @apply text-black placeholder-gray-400 focus:border-blue-500 focus:ring-blue-500;
-    @apply bg-white border-gray-300;
-    @apply dark:bg-gray-700  dark:border-gray-600;
-  }
-  .input-gray {
-    @apply text-black placeholder-gray-400;
-    @apply bg-gray-50 border-gray-300 focus:ring-primary-600 focus:border-primary-600;
-    @apply dark:bg-gray-800 dark:border-gray-600 dark:focus:ring-primary-500 dark:focus:border-primary-500;
-  }
-  .input-red {
-    @apply text-red border-red-500 focus:ring-red-500 focus:border-red-500;
-    @apply bg-red-50 placeholder-red-300;
-    @apply dark:bg-red-700/25 dark:placeholder-red-300/30;
-  }
-
-  .button-rounded-lg {
-    @apply w-full px-5 py-2.5 rounded-lg;
-    @apply font-medium text-sm text-center;
-  }
-  .button-rounded-sm {
-    @apply py-1.5 px-2.5 rounded-lg;
-    @apply font-medium text-sm;
-  }
-  .button-primary {
-    @apply focus:outline-none focus:ring-2;
-    @apply bg-primary-600 hover:bg-primary-700 disabled:bg-primary-600/50;
-    @apply text-white focus:ring-primary-300;
-    @apply dark:disabled:text-gray-400 dark:focus:ring-primary-800;
-  }
-  .button-gray {
-    @apply border focus:ring-2 focus:outline-none;
-    @apply focus:ring-blue-500 focus:border-blue-500 focus:text-blue-700;
-    @apply bg-gray-50 text-gray-900 border-gray-200 hover:bg-gray-100 hover:text-primary-600;
-    @apply dark:bg-gray-900 dark:text-gray-400 dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:text-white;
-  }
-  .button-red {
-    @apply focus:ring-2 focus:outline-none;
-    @apply text-white;
-    @apply bg-red-800 hover:bg-red-900 focus:ring-red-300;
-    @apply dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800;
-  }
-
-  .icon-button {
-    @apply rounded-lg ml-auto -mx-1.5 -my-1.5 p-1.5 flex justify-center items-center h-8 w-8 focus:ring-1 focus:ring-gray-300;
-    @apply text-gray-400 hover:bg-gray-100 hover:text-gray-900;
-    @apply dark:text-gray-500 dark:hover:bg-gray-600 dark:hover:text-white;
-  }
-}
-
-@layer utilities {
-  .bg-white {
-    @apply dark:bg-gray-900;
-  }
-
-  .text-black {
-    @apply text-gray-900;
-    @apply dark:text-white;
-  }
-  .text-gray {
-    @apply text-gray-500;
-    @apply dark:text-gray-400;
-  }
-  .text-primary {
-    @apply text-primary-600;
-    @apply dark:text-primary-500;
-  }
-  .text-red {
-    @apply text-red-500;
-  }
-
-  .toggled {
-    @apply line-through;
-    @apply bg-gray-200 text-gray-400;
-    @apply dark:bg-gray-800 dark:text-gray-600 dark:border-gray-700;
   }
 }

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -5,7 +5,7 @@ export default function AuthPage() {
   return (
     <div className="flex flex-col items-center justify-center px-6 py-8 space-y-6 mx-auto md:h-screen lg:py-0">
       <header>
-        <h1 className="flex items-center text-2xl font-semibold text-black select-none">
+        <h1 className="flex items-center text-2xl font-semibold text-gray-900 dark:text-white select-none">
           Todolist
         </h1>
       </header>

--- a/src/pages/TodolistPage.tsx
+++ b/src/pages/TodolistPage.tsx
@@ -10,7 +10,7 @@ export default function TodolistPage() {
       <header className="flex justify-between items-center w-full">
         <Link
           to="/"
-          className="flex items-center text-2xl font-semibold text-black select-none"
+          className="flex items-center text-2xl font-semibold text-gray-900 dark:text-white select-none"
         >
           Todolist
         </Link>


### PR DESCRIPTION
**문제**
`@apply` 지시문을 남용하여 tailwind components, utilities를 과하게 사용하면 코드를 확인할 때 해당 컴포넌트 코드와 `tailwind.config.js`를 번거롭게 왔다 갔다 해야 하는 수고가 발생한다.
한 눈에 스타일이 파악되지 않고 특히 layer 관련 클래스들은 우선순위가 존재해 더욱 혼란을 가중시킨다.
따라서 버튼처럼 다양한 곳에서 사용되는 스타일이 아니라면 `@apply` 지시문으로 정의하지 않는 것이 좋다.
자주 사용되는 스타일의 컴포넌트를 만드는 것이 tailwind의 취지에 더 맞다.
`@apply` 지시문을 남용하는 것은 tailwind가 아닌 기존의 css를 사용하는 것이 더 적합하다.

참고
https://velog.io/@lky5697/5-best-practices-for-preventing-chaos-in-tailwind-css
https://evilmartians.com/chronicles/5-best-practices-for-preventing-chaos-in-tailwind-css
https://tailwindcss.com/docs/reusing-styles#avoiding-premature-abstraction

**해결**
- `index.css`에 정의된 components와 utilities를 전부 제거
- 자주 사용된 icon-button 클래스는 대신 IconButton 컴포넌트를 만들어서 대체
